### PR TITLE
Added support for base64 captchas and for Google V2 ReCaptchas

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ print(captcha.await_result())
 ```
 Waits until the captcha is either solved or an error occurred (indicated through an exception).
 
+The `solve` function also receives a Base64 string as input.
+```python
+image_as_base64 = '....'
+captcha = api.solve(image_as_base64)
+print(captcha.await_result())
+```
+
 #### Solve captcha "non-blocking"
 ```python
 captcha = api.solve(captcha_file)
@@ -45,6 +52,15 @@ result = captcha.await_result()
 if use_captcha_code(result) == 'failed':
     captcha.report_bad()
 ```
+
+#### Solve a Google ReCaptcha V2 "non-blocking"
+```python
+data_key = 'data_key taken from the captcha page...'
+protected_url = 'https://www.example.com/protected/page...'
+captcha = api.solve_googlev2(data_key, protected_url)
+print(captcha.await_result())
+```
+Waits until the captcha is either solved or an error occurred (indicated through an exception).
 
 #### Query account balance
 ```python


### PR DESCRIPTION
Hi, great utility class, works like a charm for image base captchas. 

I added support to image captchas encoded in base64 in addition to files and also, support for Google ReChaptcha V2. 

For solving base64 encoded captchas the solving procedure is the same as with regular file based images like this: 

```
api = TwoCaptchaApi(_API_KEY)
captcha = api.solve(captcha_base64)
```

For the ReChaptcha V2 it goes like this:

```
api = TwoCaptchaApi(_API_KEY)
captcha = api.solve_googlev2(data_sitekey, protected_url)
```

How to get the `data_sitekey` can be found in the 2captcha docs: [https://2captcha.com/2captcha-api#solving_recaptchav2_new](url)